### PR TITLE
add 蟜

### DIFF
--- a/pinyin_simp.dict.yaml
+++ b/pinyin_simp.dict.yaml
@@ -8039,6 +8039,7 @@ sort: by_weight
 嘄	jiao	0
 趭	jiao	0
 嬓	jiao	0
+蟜	jiao	1
 穚	jiao	1
 鷮	jiao	1
 敿	jiao	1


### PR DESCRIPTION
成蟜，秦始皇嬴政的弟弟，前256年—前239年，曾被封为长安君。